### PR TITLE
[Internal] Migrate Develocity to Commonhaus Instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -238,7 +238,7 @@ void ciBuild(buildEnv, String args) {
 
 		// On untrusted nodes, we use the same access key as for PRs:
 		// it has limited access, essentially it can only push build scans.
-		def develocityCredentialsId = buildEnv.node ? 'ge.hibernate.org-access-key-pr' : 'ge.hibernate.org-access-key'
+		def develocityCredentialsId = buildEnv.node ? 'develocity.commonhaus.dev-access-key-pr' : 'develocity.commonhaus.dev-access-key'
 
 		withCredentials([string(credentialsId: develocityCredentialsId,
 				variable: 'DEVELOCITY_ACCESS_KEY')]) {
@@ -253,7 +253,7 @@ void ciBuild(buildEnv, String args) {
 		tryFinally({
 			sh "./ci/build.sh $args"
 		}, { // Finally
-			withCredentials([string(credentialsId: 'ge.hibernate.org-access-key-pr',
+			withCredentials([string(credentialsId: 'develocity.commonhaus.dev-access-key-pr',
 					variable: 'DEVELOCITY_ACCESS_KEY')]) {
 				withGradle { // withDevelocity, actually: https://plugins.jenkins.io/gradle/#plugin-content-capturing-build-scans-from-jenkins-pipeline
 					// Don't fail a build if publishing fails

--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@ Hibernate implements JPA, the standard API for object/relational persistence in 
 See https://hibernate.org/orm/[Hibernate.org] for more information.
 
 image:https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/badge/icon[Build Status,link=https://ci.hibernate.org/job/hibernate-orm-pipeline/job/main/]
-image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[link=https://ge.hibernate.org/scans]
+image:https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A[link=https://develocity.commonhaus.dev/scans?search.rootProjectNames=hibernate-orm]
 
 == Continuous Integration
 

--- a/gradle/gradle-develocity.gradle
+++ b/gradle/gradle-develocity.gradle
@@ -4,7 +4,7 @@
  */
 
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// Applies details for `https://ge.hibernate.org`
+// Applies details for `https://develocity.commonhaus.dev`
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ext {
@@ -44,7 +44,7 @@ static boolean isEnabled(String setting) {
 }
 
 develocity {
-    server = 'https://ge.hibernate.org'
+    server = 'https://develocity.commonhaus.dev'
 
     buildScan {
         capture {

--- a/nightly.Jenkinsfile
+++ b/nightly.Jenkinsfile
@@ -284,13 +284,13 @@ void runBuildOnNode(String label, Closure body) {
 void ciBuild(buildEnv, String args) {
   // On untrusted nodes, we use the same access key as for PRs:
   // it has limited access, essentially it can only push build scans.
-  def develocityCredentialsId = buildEnv.node ? 'ge.hibernate.org-access-key-pr' : 'ge.hibernate.org-access-key'
+  def develocityCredentialsId = buildEnv.node ? 'develocity.commonhaus.dev-access-key-pr' : 'develocity.commonhaus.dev-access-key'
 
   ciBuild(develocityCredentialsId, args)
 }
 
 void ciBuild(String args) {
-  ciBuild('ge.hibernate.org-access-key-pr', args)
+  ciBuild('develocity.commonhaus.dev-access-key-pr', args)
 }
 
 void ciBuild(String develocityCredentialsId, String args) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 plugins {
     id 'org.hibernate.orm.build.env-settings'
     id 'org.hibernate.orm.build.jdks-settings'
-    id 'com.gradle.develocity' version '3.17.6'
-    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
+    id 'com.gradle.develocity' version '3.19.2'
+    id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.1'
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
<!--
If this is your first time contributing to the project, please consider reviewing https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md
-->

- Updated the Develocity and Common Custom User Data Gradle Plugins to their latest verisons
- Updated the Develocity Gradle Plugin's `server` to point to `https://develocity.commonhaus.dev`
- Changed other references from `ge.hibernate.org` to `develocity.commonhaus.dev`
  - Jenkins credential IDs
  - `Revved up by Develocity` badge URL

<!--
Please read and do not remove the following lines:
-->
----------------------
By submitting this pull request, I confirm that my contribution is made under the terms of the [Apache 2.0 license](https://www.apache.org/licenses/LICENSE-2.0.txt)
and can be relicensed under the terms of the [LGPL v2.1 license](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.txt) in the future at the maintainers' discretion.
For more information on licensing, please check [here](https://github.com/hibernate/hibernate-orm/blob/main/CONTRIBUTING.md#legal).

----------------------
